### PR TITLE
Download script and updated version numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 vm:
 	vagrant up
 
-es_version = 0.18.7
+es_version = 0.19.4
 es_tarchive = elasticsearch-$(es_version).tar.gz
 es_source = http://cloud.github.com/downloads/elasticsearch/elasticsearch
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ elasticsearch version 0.19. I can't use 0.19 with the current version of
     cd elasticsearch
     make fetch # for default 0.18.7 download
 
+Without `make`, do `./download.sh`.
+
 ## Usage
 
     class { 'elasticsearch':

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 
 Vagrant::Config.run do |config|
   config.vm.box = "lucid32"
+  config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
   config.vm.host_name = "elasticsearch"
   config.vm.network :hostonly, "192.168.31.46"
   config.vm.share_folder "modules/elasticsearch", "/tmp/vagrant-puppet/modules/elasticsearch", ".", :create => true

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo -e "Type version to download (at time of writing "0.19.4"): \c"
+read es_version
+es_tarchive="elasticsearch-$es_version.tar.gz"
+es_source="http://cloud.github.com/downloads/elasticsearch/elasticsearch"
+curl -o files/$es_tarchive $es_source/$es_tarchive

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class elasticsearch::params {
-  $version = "0.18.7"
+  $version = "0.19.4"
   $java_package = "openjdk-6-jre-headless"
   $dbdir = "/var/lib/elasticsearch"
   $logdir = "/var/log/elasticsearch"


### PR DESCRIPTION
Hello,

Since git doesn't install with `make` by default on Windows boxes, I added a small shell script that downloads the file similar to how the makefile does it, but with bash. See the commits, they are pretty small.
