### PR TITLE
Fixing puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 metadata.json
 pkg
 .vagrant
+.project

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 vm:
 	vagrant up
 
-es_version = 0.18.7
+es_version = 0.19.4
 es_tarchive = elasticsearch-$(es_version).tar.gz
 es_source = http://cloud.github.com/downloads/elasticsearch/elasticsearch
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ elasticsearch version 0.19. I can't use 0.19 with the current version of
     cd elasticsearch
     make fetch # for default 0.18.7 download
 
+Without `make`, do `./download.sh`.
+
 ## Usage
 
     class { 'elasticsearch':

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant::Config.run do |config|
   config.vm.host_name = "elasticsearch"
   config.vm.network :hostonly, "192.168.31.46"
   config.vm.share_folder "modules/elasticsearch", "/tmp/vagrant-puppet/modules/elasticsearch", ".", :create => true
+
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "tests"
     puppet.manifest_file = "vagrant.pp"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 
 Vagrant::Config.run do |config|
   config.vm.box = "lucid32"
+  config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
   config.vm.host_name = "elasticsearch"
   config.vm.network :hostonly, "192.168.31.46"
   config.vm.share_folder "modules/elasticsearch", "/tmp/vagrant-puppet/modules/elasticsearch", ".", :create => true

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo -e "Type version to download (at time of writing "0.19.4"): \c"
+read es_version
+es_tarchive="elasticsearch-$es_version.tar.gz"
+es_source="http://cloud.github.com/downloads/elasticsearch/elasticsearch"
+curl -o files/$es_tarchive $es_source/$es_tarchive

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,10 +133,18 @@ class elasticsearch(
     ensure => present,
     source => "puppet:///elasticsearch/etc-init-elasticsearch.conf",
   }
+  
+  # for http://projects.puppetlabs.com/issues/14297
+  file { '/etc/init.d/elasticsearch':
+    ensure => link,
+    target => "/lib/init/upstart-job",
+  }
 
   service { 'elasticsearch':
-    ensure   => running, 
-    enable   => true,
-    provider => upstart,
+    ensure        => running, 
+    hasrestart    => true,
+    hasstatus     => true,
+    provider      => 'upstart',
+    subscribe     => [ File[$upstartfile], File['/etc/init.d/elasticsearch'] ],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class elasticsearch::params {
-  $version = "0.18.7"
+  $version = "0.19.4"
   $java_package = "openjdk-6-jre-headless"
   $dbdir = "/var/lib/elasticsearch"
   $logdir = "/var/log/elasticsearch"

--- a/tests/vagrant.pp
+++ b/tests/vagrant.pp
@@ -4,8 +4,8 @@ class apt_get_update {
   $sentinel = "/var/lib/apt/first-puppet-run"
 
   exec { "initial apt-get update":
-    command => "/usr/bin/apt-get update && touch ${sentinel}",
-    onlyif  => "/usr/bin/env test \\! -f ${sentinel} || /usr/bin/env test \\! -z \"$(find /etc/apt -type f -cnewer ${sentinel})\"",
+    command => "/usr/bin/apt-get update && touch ${::sentinel}",
+    onlyif  => "/usr/bin/env test \\! -f ${::sentinel} || /usr/bin/env test \\! -z \"$(find /etc/apt -type f -cnewer ${::sentinel})\"",
     timeout => 3600,
   }
 }


### PR DESCRIPTION
Hi there again,

I tried to run the module with the vagrant file and unfortunately didn't succeed because Service[elasticsearch] failed with 'cannot find init script'. After a bit of googling I came up with [this puppetlabs bug](http://projects.puppetlabs.com/issues/14297) which discusses the same issue. In the mean-time, there's no hard in symlinking.

The pull request depends on the previous and also fixes some possible scoping issues for variables as identified with gepetto.
